### PR TITLE
Issue #2

### DIFF
--- a/include/ptlib/thread.h
+++ b/include/ptlib/thread.h
@@ -423,40 +423,6 @@ class PThread : public PObject
   */
 
 /*
-   This class automates calling a global function with no arguments within it's own thread.
-   It is used as follows:
-
-   void GlobalFunction()
-   {
-   }
-
-   ...
-   PString arg;
-   new PThreadMain(&GlobalFunction)
- */
-class PThreadMain : public PThread
-{
-    PCLASSINFO(PThreadMain, PThread);
-  public:
-    typedef void (*FnType)(); 
-    PThreadMain(FnType function, bool autoDel = false)
-      : PThread(10000, autoDel ? PThread::AutoDeleteThread : PThread::NoAutoDeleteThread)
-      , m_function(function)
-    {
-      PThread::Resume();
-    }
-
-    virtual void Main()
-    {
-      (*m_function)();
-    }
-
-  protected:
-    FnType m_function;
-};
-
-
-/*
    This template automates calling a global function using a functor
    It is used as follows:
 
@@ -477,7 +443,6 @@ class PThreadFunctor : public PThread
       : PThread(10000, autoDel ? PThread::AutoDeleteThread : PThread::NoAutoDeleteThread)
       , m_funct(funct)
     {
-      PThread::Resume();
     }
 
     virtual void Main()
@@ -487,141 +452,6 @@ class PThreadFunctor : public PThread
 
   protected:
     Functor & m_funct;
-};
-
-
-/*
-   This template automates calling a global function with one argument within it's own thread.
-   It is used as follows:
-
-   void GlobalFunction(PString arg)
-   {
-   }
-
-   ...
-   PString arg;
-   new PThread1Arg<PString>(arg, &GlobalFunction)
- */
-template<typename Arg1Type>
-class PThread1Arg : public PThread
-{
-    PCLASSINFO(PThread1Arg, PThread);
-  public:
-    typedef void (*FnType)(Arg1Type arg1);
-
-    PThread1Arg(
-      Arg1Type arg1,
-      FnType function,
-      bool autoDel = false,
-      const char * name = NULL,
-      PThread::Priority priority = PThread::NormalPriority
-    ) : PThread(10000, autoDel ? PThread::AutoDeleteThread : PThread::NoAutoDeleteThread, priority, name)
-      , m_function(function)
-      , m_arg1(arg1)
-    {
-      PThread::Resume();
-    }
-
-    virtual void Main()
-    {
-      (*m_function)(m_arg1);
-    }
-
-  protected:
-    FnType   m_function;
-    Arg1Type m_arg1;
-};
-
-
-/*
-   This template automates calling a global function with two arguments within it's own thread.
-   It is used as follows:
-
-   void GlobalFunction(PString arg1, int arg2)
-   {
-   }
-
-   ...
-   PString arg;
-   new PThread2Arg<PString, int>(arg1, arg2, &GlobalFunction)
- */
-template<typename Arg1Type, typename Arg2Type>
-class PThread2Arg : public PThread
-{
-    PCLASSINFO(PThread2Arg, PThread);
-  public:
-    typedef void (*FnType)(Arg1Type arg1, Arg2Type arg2); 
-    PThread2Arg(
-      Arg1Type arg1,
-      Arg2Type arg2,
-      FnType function,
-      bool autoDel = false,
-      const char * name = NULL,
-      PThread::Priority priority = PThread::NormalPriority
-    ) : PThread(10000, autoDel ? PThread::AutoDeleteThread : PThread::NoAutoDeleteThread, priority, name)
-      , m_function(function)
-      , m_arg1(arg1)
-      , m_arg2(arg2)
-    {
-      PThread::Resume();
-    }
-    
-    virtual void Main()
-    {
-      (*m_function)(m_arg1, m_arg2);
-    }
-
-  protected:
-    FnType   m_function;
-    Arg1Type m_arg1;
-    Arg2Type m_arg2;
-};
-
-/*
-   This template automates calling a global function with three arguments within it's own thread.
-   It is used as follows:
-
-   void GlobalFunction(PString arg1, int arg2, int arg3)
-   {
-   }
-
-   ...
-   PString arg;
-   new PThread3Arg<PString, int, int>(arg1, arg2, arg3, &GlobalFunction)
- */
-template<typename Arg1Type, typename Arg2Type, typename Arg3Type>
-class PThread3Arg : public PThread
-{
-  PCLASSINFO(PThread3Arg, PThread);
-  public:
-    typedef void (*FnType)(Arg1Type arg1, Arg2Type arg2, Arg3Type arg3); 
-    PThread3Arg(
-      Arg1Type arg1,
-      Arg2Type arg2,
-      Arg3Type arg3,
-      FnType function,
-      bool autoDel = false,
-      const char * name = NULL,
-      PThread::Priority priority = PThread::NormalPriority
-    ) : PThread(10000, autoDel ? PThread::AutoDeleteThread : PThread::NoAutoDeleteThread, priority, name)
-      , m_function(function)
-      , m_arg1(arg1)
-      , m_arg2(arg2)
-      , m_arg3(arg3)
-    {
-      PThread::Resume();
-    }
-    
-    virtual void Main()
-    {
-      (*m_function)(m_arg1, m_arg2, m_arg3);
-    }
-
-  protected:
-    FnType   m_function;
-    Arg1Type m_arg1;
-    Arg2Type m_arg2;
-    Arg2Type m_arg3;
 };
 
 /*
@@ -660,7 +490,6 @@ class PThreadObj : public PThread
       , m_object(obj)
       , m_function(function)
     {
-      PThread::Resume();
     }
 
     void Main()
@@ -672,99 +501,6 @@ class PThreadObj : public PThread
     ObjType & m_object;
     ObjTypeFn P_ALIGN_FIELD(m_function, 8);
 };
-
-
-/*
-   This template automates calling a member function with one argument within it's own thread.
-   It is used as follows:
-
-   class Example {
-     public:
-      void Function(PString arg)
-      {
-      }
-   };
-
-   ...
-   Example ex;
-   PString str;
-   new PThreadObj1Arg<Example>(ex, str, &Example::Function)
- */
-template <class ObjType, typename Arg1Type>
-class PThreadObj1Arg : public PThread
-{
-    PCLASSINFO(PThreadObj1Arg, PThread);
-  public:
-    typedef void (ObjType::*ObjTypeFn)(Arg1Type); 
-
-    PThreadObj1Arg(
-      ObjType & obj,
-      Arg1Type arg1,
-      ObjTypeFn function,
-      bool autoDel = false,
-      const char * name = NULL,
-      PThread::Priority priority = PThread::NormalPriority
-    ) : PThread(10000,
-                autoDel ? PThread::AutoDeleteThread : PThread::NoAutoDeleteThread,
-                priority,
-                name)
-      , m_object(obj)
-      , m_function(function)
-      , m_arg1(arg1)
-    {
-      PThread::Resume();
-    }
-
-    void Main()
-    {
-      (m_object.*m_function)(m_arg1);
-    }
-
-  protected:
-    ObjType & m_object;
-    ObjTypeFn P_ALIGN_FIELD(m_function, 8);
-    Arg1Type  m_arg1;
-};
-
-template <class ObjType, typename Arg1Type, typename Arg2Type>
-class PThreadObj2Arg : public PThread
-{
-    PCLASSINFO(PThreadObj2Arg, PThread);
-  public:
-    typedef void (ObjType::*ObjTypeFn)(Arg1Type, Arg2Type);
-
-    PThreadObj2Arg(
-      ObjType & obj,
-      Arg1Type arg1,
-      Arg2Type arg2,
-      ObjTypeFn function,
-      bool autoDel = false,
-      const char * name = NULL,
-      PThread::Priority priority = PThread::NormalPriority
-    ) : PThread(10000,
-                autoDel ? PThread::AutoDeleteThread : PThread::NoAutoDeleteThread,
-                priority,
-                name)
-      , m_object(obj)
-      , m_function(function)
-      , m_arg1(arg1)
-      , m_arg2(arg2)
-    {
-      PThread::Resume();
-    }
-
-    void Main()
-    {
-      (m_object.*m_function)(m_arg1, m_arg2);
-    }
-
-  protected:
-    ObjType & m_object;
-    ObjTypeFn P_ALIGN_FIELD(m_function, 8);
-    Arg1Type  m_arg1;
-    Arg2Type  m_arg2;
-};
-
 
 ///////////////////////////////////////////////////////////////////////////////
 //

--- a/samples/audio/audio.cxx
+++ b/samples/audio/audio.cxx
@@ -241,7 +241,10 @@ void TestAudioDevice::Test(const PString & captureFileName)
    PTRACE(3, "Start operation of TestAudioDevice");
 
    TestAudioRead reader(*this, captureFileName);
-   TestAudioWrite writer(*this);   
+   reader.Resume();
+
+   TestAudioWrite writer(*this);
+   writer.Resume();
 
 
    PStringStream help;
@@ -359,9 +362,8 @@ PBoolean TestAudioDevice::DoEndNow()
 TestAudioRead::TestAudioRead(TestAudioDevice &master, const PString & _captureFileName)
     :TestAudio(master),
      captureFileName(_captureFileName)
-{    
+{
   PTRACE(3, "Reader\tInitiate thread for reading " );
-  Resume();
 }
 
 void TestAudioRead::ReportIterations()
@@ -408,7 +410,6 @@ TestAudioWrite::TestAudioWrite(TestAudioDevice &master)
    : TestAudio(master)
 {
   PTRACE(3, "Reader\tInitiate thread for writing " );
-  Resume();
 }
 
 void TestAudioWrite::ReportIterations()

--- a/samples/audio/audio.h
+++ b/samples/audio/audio.h
@@ -55,7 +55,7 @@ PDECLARE_LIST(TestAudioDevice, PBYTEArray *)
 
 
 
-class TestAudio : public PThread  
+class TestAudio : public PThread
 {
   PCLASSINFO(TestAudio, PThread)
   public:

--- a/samples/ether/ether.cxx
+++ b/samples/ether/ether.cxx
@@ -110,11 +110,17 @@ void MyProcess::Main()
   }
 
   PList<TestThread> tests;
-  do {
-    tests.Append(new TestThread(tests.GetSize()+1, args));
-    if (!tests.back().IsOpen())
-      return;
-  } while (args.Parse());
+  do
+  {
+      TestThread * thread = new TestThread(tests.GetSize() + 1, args);
+      thread->Resume();
+      tests.Append(thread);
+      if (!tests.back().IsOpen())
+      {
+          return;
+      }
+  }
+  while (args.Parse());
 
   m_exit.Wait();
 
@@ -157,8 +163,6 @@ TestThread::TestThread(PINDEX idx, PArgList & args)
     cerr << "Could not use filter \"" << filter << '"' << endl;
     m_socket.Close();
   }
-
-  Resume();
 }
 
 

--- a/samples/scatter/main.cxx
+++ b/samples/scatter/main.cxx
@@ -120,7 +120,7 @@ void ScatterTest::Main()
 
   WaitForIncoming waiter(rxSocket);
   PThread * thread = new PThreadFunctor<WaitForIncoming>(waiter);
-
+  thread->Resume();
 
   // send some test data
   PUDPSocket txSocket;

--- a/samples/serial/serial.cxx
+++ b/samples/serial/serial.cxx
@@ -57,7 +57,10 @@ class UserInterfaceThread : public PThread
     PCLASSINFO(UserInterfaceThread, PThread);
   public:
     UserInterfaceThread(Serial & _srl)
-      : PThread(1000, NoAutoDeleteThread), srl(_srl) { Resume(); }
+        : PThread(1000, NoAutoDeleteThread)
+        , srl(_srl)
+    {
+    }
 
     void Main()
       { srl.HandleConsoleInput(); }
@@ -71,7 +74,10 @@ class SerialInterfaceThread : public PThread
     PCLASSINFO(SerialInterfaceThread, PThread);
 public:
     SerialInterfaceThread(Serial & _srl)
-      : PThread(1000, NoAutoDeleteThread), srl(_srl) { Resume(); }
+        : PThread(1000, NoAutoDeleteThread)
+        , srl(_srl)
+    {
+    }
 
     void Main()
       { srl.HandleSerialInput(); }
@@ -169,8 +175,11 @@ void Serial::Main()
       return;
   }
 
-  UserInterfaceThread *ui = new UserInterfaceThread(*this);
-  SerialInterfaceThread *si = new SerialInterfaceThread(*this);
+  UserInterfaceThread * ui = new UserInterfaceThread(*this);
+  ui->Resume();
+
+  SerialInterfaceThread * si = new SerialInterfaceThread(*this);
+  si->Resume();
 
   ui->WaitForTermination();
 

--- a/samples/sortedlist/SortedListTest.cxx
+++ b/samples/sortedlist/SortedListTest.cxx
@@ -82,11 +82,19 @@ void SortedListTest::Main()
     ss.erase(found);
   }
 
-  for (PINDEX i = 0; i < 15; i++) {
+  for (PINDEX i = 0; i < 15; i++)
+  {
+      PThread * thread = NULL;
     if (i < 10)
-      new DoSomeThing1(i);
+    {
+      thread = new DoSomeThing1(i);
+    }
     else
-      new DoSomeThing2(i);
+    {
+      thread = new DoSomeThing2(i);
+    }
+
+      thread->Resume();
   }
 
   Suspend();
@@ -96,7 +104,6 @@ void SortedListTest::Main()
 DoSomeThing1::DoSomeThing1(PINDEX _index)
   : PThread(1000, AutoDeleteThread, NormalPriority, psprintf("DoSomeThing1 %u", _index)), index(_index)
 {
-  Resume();
 }
 
 
@@ -158,7 +165,6 @@ DoSomeThing2::DoSomeThing2(PINDEX _index)
   : PThread(1000, AutoDeleteThread, NormalPriority, psprintf("DoSomeThing2 %u", _index))
   , index(_index)
 {
-  Resume();
 }
 
 

--- a/samples/strtest/main.cxx
+++ b/samples/strtest/main.cxx
@@ -134,8 +134,9 @@ class StringHolder
       PCLASSINFO(TestThread, PThread);
       public:
         TestThread(StringHolder & _holder) 
-        : PThread(1000,NoAutoDeleteThread), holder(_holder)
-        { Resume(); }
+            : PThread(1000,NoAutoDeleteThread), holder(_holder)
+        {
+        }
 
         void Main() 
         { int count = 0; while (!finishFlag && count < COUNT_MAX) holder.TestString(count++, "sub"); }
@@ -145,9 +146,11 @@ class StringHolder
 
     PThread * StartThread()
     {
-      return new TestThread(*this);
-    }
+        PThread * thread = new TestThread(*this);
+        thread->Resume();
 
+        return thread;
+    }
 };
 
 struct PStringConv : public StringConv<PString> {

--- a/samples/syncpoints/main.cxx
+++ b/samples/syncpoints/main.cxx
@@ -104,11 +104,13 @@ void SyncPoints::Main()
   }
 
   Runner *lastRunner = NULL;
-  for (PINDEX i = 0; i < size; i++) {
+  for (PINDEX i = 0; i < size; i++)
+  {
     Runner * thisRunner = new Runner(*this, lastRunner, i);
-    
+    thisRunner->Resume();
+
     list.push_back(thisRunner);
-    lastRunner = thisRunner;    
+    lastRunner = thisRunner;
   }
 
   PTime a;
@@ -140,7 +142,6 @@ Runner::Runner(SyncPoints & _app, Runner * _nextThread, PINDEX _id)
    nextThread(_nextThread),
    id(_id)
 {
-  Resume();
 }
 
 void Runner::Main()

--- a/samples/thread/thread.cxx
+++ b/samples/thread/thread.cxx
@@ -47,9 +47,9 @@ class MyThread1 : public PThread
 {
   PCLASSINFO(MyThread1, PThread);
   public:
-    MyThread1() : PThread(1000,NoAutoDeleteThread)
+    MyThread1()
+        : PThread(1000,NoAutoDeleteThread)
     {
-      Resume(); // start running this thread when it is created.
     }
 
     void Main() {
@@ -81,7 +81,9 @@ class MyThread2 : public PThread
 {
   PCLASSINFO(MyThread2, PThread);
   public:
-    MyThread2() : PThread(1000,NoAutoDeleteThread) {
+    MyThread2()
+        : PThread(1000,NoAutoDeleteThread)
+    {
       exitFlag = false;
     }
 
@@ -145,6 +147,7 @@ void ThreadTest::Main()
   MyThread2 * mythread2;
 
   mythread1 = new MyThread1();
+  mythread1->Resume();
   mythread2 = new MyThread2();
 
 

--- a/samples/vxmltest/main.cxx
+++ b/samples/vxmltest/main.cxx
@@ -34,7 +34,8 @@ class ChannelCopyThread : public PThread
   public:
     ChannelCopyThread(PChannel & _from, PChannel & _to)
       : PThread(1000, NoAutoDeleteThread), from(_from), to(_to)
-    { Resume(); }
+    {
+    }
 
     void Main();
 
@@ -127,6 +128,7 @@ void Vxmltest::Main()
 
   cout << "Starting media" << endl;
   PThread * thread1 = new ChannelCopyThread(*vxml, player);
+  thread1->Resume();
 
   inputRunning = true;
   PThread * inputThread = PThread::Create(PCREATE_NOTIFIER(InputThread), 0, NoAutoDeleteThread);

--- a/samples/xmppconsole/main.cxx
+++ b/samples/xmppconsole/main.cxx
@@ -304,10 +304,8 @@ void XMPPConsole::Main()
   
   frame.ConnectNow();
 
-  
-   
-
-  UserInterface ui (frame);
+  UserInterface ui(frame);
+  ui.Resume();
   ui.WaitForTermination();
   frame.DisconnectNow();
 

--- a/samples/xmppconsole/main.h
+++ b/samples/xmppconsole/main.h
@@ -108,7 +108,8 @@ class UserInterface: public PThread
 public:
   UserInterface(XMPPFrame & _frame)
     : PThread(1000, NoAutoDeleteThread),  frame(_frame)
-    { Resume(); }
+    {
+    }
    
   void Main();
      

--- a/src/ptclib/httpsvc.cxx
+++ b/src/ptclib/httpsvc.cxx
@@ -209,11 +209,13 @@ bool PHTTPServiceProcess::ListenForHTTP(const PString & interfaces,
   }
 
   if (atLeastOne && stackSize > 1000)
-    new PHTTPServiceThread(stackSize, *this);
+  {
+    PThread * thread = new PHTTPServiceThread(stackSize, *this);
+    thread->Resume();
+  }
 
   return atLeastOne;
 }
-
 
 bool PHTTPServiceProcess::ListenForHTTP(PSocket * listener,
                                         PSocket::Reusability reuse,
@@ -235,7 +237,10 @@ bool PHTTPServiceProcess::ListenForHTTP(PSocket * listener,
   m_httpListeningSockets.Append(listener);
 
   if (stackSize > 1000)
-    new PHTTPServiceThread(stackSize, *this);
+  {
+    PThread * thread = new PHTTPServiceThread(stackSize, *this);
+    thread->Resume();
+  }
 
   return true;
 }
@@ -465,9 +470,7 @@ PHTTPServiceThread::PHTTPServiceThread(PINDEX stackSize,
 
   myStackSize = stackSize;
   socket = NULL;
-  Resume();
 }
-
 
 PHTTPServiceThread::~PHTTPServiceThread()
 {
@@ -477,23 +480,22 @@ PHTTPServiceThread::~PHTTPServiceThread()
   delete socket;
 }
 
-
 void PHTTPServiceThread::Close()
 {
   if (socket != NULL)
     socket->Close();
 }
 
-
 void PHTTPServiceThread::Main()
 {
   socket = process.AcceptHTTP();
-  if (socket != NULL) {
-    new PHTTPServiceThread(myStackSize, process);
+  if (socket != NULL)
+  {
+    PThread * thread = new PHTTPServiceThread(myStackSize, process);
+    thread->Resume();
     process.ProcessHTTP(*socket);
   }
 }
-
 
 //////////////////////////////////////////////////////////////
 

--- a/src/ptclib/psockbun.cxx
+++ b/src/ptclib/psockbun.cxx
@@ -100,6 +100,7 @@ void PInterfaceMonitor::Start()
       m_changedDetector = PIPSocket::CreateRouteTableDetector();
       m_updateThread = new PThreadObj<PInterfaceMonitor>(*this, &PInterfaceMonitor::UpdateThreadMain);
       m_updateThread->SetThreadName("Network Interface Monitor");
+      m_updateThread->Resume();
     }
   }
 }

--- a/src/ptclib/pstun.cxx
+++ b/src/ptclib/pstun.cxx
@@ -1707,8 +1707,6 @@ void AllocateSocketFunctor::operator () (PThread &)
   }
 }
 
-typedef PThreadFunctor<AllocateSocketFunctor> AllocateSocketThread;
-
 bool PTURNClient::CreateSocket(Component component, PUDPSocket * & socket, const PIPSocket::Address & binding, WORD port)
 {
   if (component != PNatMethod::eComponent_RTP && component != PNatMethod::eComponent_RTCP)
@@ -1771,7 +1769,10 @@ bool PTURNClient::CreateSocketPair(PUDPSocket * & socket1,
   AllocateSocketFunctor op1(*this, PNatMethod::eComponent_RTP,   binding, pairedPortInfo);
   AllocateSocketFunctor op2(*this, PNatMethod::eComponent_RTCP,  binding, pairedPortInfo);
   PThread * thread1 = new PThreadFunctor<AllocateSocketFunctor>(op1);
+  thread1->Resume();
+
   PThread * thread2 = new PThreadFunctor<AllocateSocketFunctor>(op2);
+  thread2->Resume();
 
   PTRACE(3, "TURN\tWaiting for allocations to complete");
   thread1->WaitForTermination();

--- a/src/ptclib/spooldir.cxx
+++ b/src/ptclib/spooldir.cxx
@@ -54,6 +54,7 @@ bool PSpoolDirectory::Open(const PDirectory & dir, const PString & type)
 
   PTRACE(3, "PSpoolDirectory\tThread started " << m_threadRunning);
   m_thread = new PThreadObj<PSpoolDirectory>(*this, &PSpoolDirectory::ThreadMain);
+  m_thread->Resume();
 
   m_directory = dir;
   m_fileType  = type;

--- a/src/ptclib/vsdl.cxx
+++ b/src/ptclib/vsdl.cxx
@@ -101,6 +101,7 @@ class PSDL_Window : public PMutex
     {
       if (m_thread == NULL) {
         m_thread = new PThreadObj<PSDL_Window>(*this, &PSDL_Window::MainLoop, true, SDLName);
+        m_thread->Resume();
         m_started.Wait();
       }
     }

--- a/src/ptlib/Nucleus++/NucleusConfig.cxx
+++ b/src/ptlib/Nucleus++/NucleusConfig.cxx
@@ -155,7 +155,6 @@ PXConfigWriteThread::PXConfigWriteThread(PSyncPointAck & s)
   : PThread(10000, AutoDeleteThread),
     stop(s)
 {
-  Resume();
 }
 
 PXConfigWriteThread::~PXConfigWriteThread()
@@ -423,7 +422,10 @@ PXConfig * PXConfigDictionary::GetFileConfigInstance(const PFilePath & key, cons
 
   // start write thread, if not already started
   if (writeThread == NULL)
+  {
     writeThread = new PXConfigWriteThread(stopConfigWriteThread);
+    writeThread->Resume();
+  }
 
   PXConfig * config = GetAt(key);
   if (config != NULL) 

--- a/src/ptlib/common/osutils.cxx
+++ b/src/ptlib/common/osutils.cxx
@@ -1894,7 +1894,6 @@ void PProcess::Startup()
   }
 }
 
-
 bool PProcess::SignalTimerChange()
 {
   if (!PAssert(IsInitialised(), PLogicError) || m_shuttingDown) 
@@ -1903,11 +1902,13 @@ bool PProcess::SignalTimerChange()
   if (m_keepingHouse.TestAndSet(true))
     m_signalHouseKeeper.Signal();
   else
+  {
     m_houseKeeper = new PThreadObj<PProcess>(*this, &PProcess::HouseKeeping, false, "PTLib Housekeeper");
+    m_houseKeeper->Resume();
+  }
 
   return true;
 }
-
 
 void PProcess::PreShutdown()
 {

--- a/src/ptlib/common/pethsock.cxx
+++ b/src/ptlib/common/pethsock.cxx
@@ -694,6 +694,7 @@ bool PEthSocketThread::Start(const PString & device, const PString & filter)
   if (m_socket->Connect(device) && m_socket->SetFilter(filter)) {
     m_running = true;
     m_thread = new PThreadObj<PEthSocketThread>(*this, &PEthSocketThread::MainLoop, false, "Sniffer");
+    m_thread->Resume();
     return true;
   }
 

--- a/src/ptlib/unix/config.cxx
+++ b/src/ptlib/unix/config.cxx
@@ -151,9 +151,7 @@ PXConfigWriteThread::PXConfigWriteThread(PSyncPointAck & s)
   : PThread(10000, NoAutoDeleteThread, NormalPriority, "PXConfigWriteThread"),
     stop(s)
 {
-  Resume();
 }
-
 
 void PXConfigWriteThread::Main()
 {
@@ -422,7 +420,10 @@ PXConfig * PXConfigDictionary::GetFileConfigInstance(const PString & key, const 
 
   // start write thread, if not already started
   if (writeThread == NULL)
+  {
     writeThread = new PXConfigWriteThread(stopConfigWriteThread);
+    writeThread->Resume();
+  }
 
   PXConfig * config = GetAt(key);
   if (config == NULL) {

--- a/src/ptlib/unix/svcproc.cxx
+++ b/src/ptlib/unix/svcproc.cxx
@@ -631,9 +631,12 @@ void PServiceProcess::PXOnSignal(int sig)
     case SIGINT :
     case SIGHUP :
     case SIGTERM :
+    {
       PTRACE(3, "PTLib", "Starting thread to terminate service process, signal " << sig);
-      new PThreadObj<PServiceProcess>(*this, &PServiceProcess::Terminate);
+      PThread * thread = new PThreadObj<PServiceProcess>(*this, &PServiceProcess::Terminate);
+      thread->Resume();
       return;
+    }
 
     case TraceUpSignal :
       if (GetLogLevel() < PSystemLog::NumLogLevels-1) {

--- a/src/ptlib/wm/cegps.cxx
+++ b/src/ptlib/wm/cegps.cxx
@@ -43,7 +43,7 @@
 
 
 PGPS::PGPS()
-: PThread(10000, AutoDeleteThread, LowPriority, "GPS")
+    : PThread(10000, AutoDeleteThread, LowPriority, "GPS")
 {
 	s_hGPS_Device = NULL;
 	s_hNewLocationData = NULL;
@@ -52,7 +52,6 @@ PGPS::PGPS()
 
 	gpsRunning = false;
 	closeThread = false;
-	Resume();
 }
 
 PGPS::~PGPS()


### PR DESCRIPTION
Issue #2 

Remove all helper classes from thread.h except PThreadObj and
PThreadFunctor. Fix their usage.
Fix usage of PThread in samples.
Fix usage of PThread in the library itself (in core).
